### PR TITLE
Install getpwuid to workaround Openshift random UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,11 @@ RUN curl --fail -sSLo /etc/yum.repos.d/passenger.repo https://oss-binaries.phusi
 RUN yum install -y passenger || yum-config-manager --enable cr && yum install -y passenger && \
     yum clean all -y
 RUN /usr/bin/passenger-config validate-install
+# Passenger relies on getpwuid - this doesn't work on Openshift as Openshift
+# assigns a random UID for every new pod. Instead, we can preload this library
+# to mitigate the problem
+RUN curl https://raw.githubusercontent.com/appuio/libmapuid/master/lib/libmapuid.so -o /usr/local/lib/libmapuid.so && \
+    chmod 755 /usr/local/lib/libmapuid.so
 
 USER 1001
 


### PR DESCRIPTION
`passenger start` requires a coherent `getpwuid` response. Currently that's not going to happen, because the UIDs in Openshift pods are random. Therefore, we hit this 
```
[ N 2019-04-15 09:48:55.0003 47/T5 age/Cor/SecurityUpdateChecker.h:519 ]: Security update check: no update found (next check in 24 hours)
--
  | [ E 2019-04-15 09:48:55.5844 47/Tr age/Cor/App/Implementation.cpp:221 ]: Could not spawn process for application /opt/app-root/src: An internal error occurred while preparing to spawn an application process: Cannot get user database entry for user UID 1026090000; it looks like your system's user database is broken, please fix it.
  | Error ID: a7b9e563
  | Error details saved to: /tmp/passenger-error-6k49CN.html
```

I was reading the source and I don't think there's much of an option here, either create a temporary UID to run passenger, or use a library like this.

https://github.com/phusion/passenger/blob/master/src/agent/Core/SpawningKit/UserSwitchingRules.h#L83

Here's how to workaround it creating a temporary UID: https://major.io/2019/03/22/running-ansible-in-openshift-with-arbitrary-uids/