### PR TITLE
Ensure SIGTERM is passed to PID 1 on OOM error

### DIFF
--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -48,9 +48,9 @@ if [ "$APPLICATION_TYPE" = "compliance-backend" ]; then
 		fi
 	fi
 elif [ "$APPLICATION_TYPE" = "compliance-consumer" ]; then
-	bundle exec racecar ComplianceReportsConsumer
+	exec bundle exec racecar ComplianceReportsConsumer
 elif [ "$APPLICATION_TYPE" = "compliance-sidekiq" ]; then
-	bundle exec sidekiq
+	exec bundle exec sidekiq
 elif [ "$APPLICATION_TYPE" = "compliance-prometheus-exporter" ]; then
-	bundle exec prometheus_exporter -c lib/graphql_collector.rb --prefix compliance_
+	exec bundle exec prometheus_exporter -c lib/graphql_collector.rb --prefix compliance_
 fi


### PR DESCRIPTION
Running the Sidekiq (or any other) process as a child of 'run' caused
the process to NOT get any signal when it was killed from out of memory
errors.

By passing 'exec' when we call it, we substitut the PID 1 of the
container from 's2i/bin/run' to the actual process running, which is
what we want to get the SIGTERM signal.

Without `exec`:
```
2019-04-17T09:37:23.492Z 13639 TID-gt7yl9v7r INFO: Running in ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
2019-04-17T09:37:23.493Z 13639 TID-gt7yl9v7r INFO: See LICENSE and the LGPL-3.0 for licensing details.
2019-04-17T09:37:23.493Z 13639 TID-gt7yl9v7r INFO: Upgrade to Sidekiq Pro for more features and support: http://sidekiq.org
2019-04-17T09:37:23.495Z 13639 TID-gt7yl9v7r INFO: Starting processing, hit Ctrl-C to stop
Terminated
``` 
With `exec`:
```ruby
2019-04-17T09:44:33.834Z 15304 TID-gq1xgoq48 INFO: Running in ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux]
2019-04-17T09:44:33.835Z 15304 TID-gq1xgoq48 INFO: See LICENSE and the LGPL-3.0 for licensing details.
2019-04-17T09:44:33.835Z 15304 TID-gq1xgoq48 INFO: Upgrade to Sidekiq Pro for more features and support: http://sidekiq.org
2019-04-17T09:44:33.836Z 15304 TID-gq1xgoq48 INFO: Starting processing, hit Ctrl-C to stop
2019-04-17T09:44:40.719Z 15304 TID-gq1xgoq48 INFO: Shutting down
2019-04-17T09:44:40.720Z 15304 TID-gq1xgoq48 INFO: Terminating quiet workers
2019-04-17T09:44:40.720Z 15304 TID-gq1yijcog INFO: Scheduler exiting...
2019-04-17T09:44:40.820Z 15304 TID-gq1xgoq48 INFO: Pausing to allow workers to finish... <---------------------
2019-04-17T09:44:43.928Z 15304 TID-gq1xgoq48 INFO: Bye!
```