### PR TITLE
Make sure graphql collector is running

### DIFF
--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -52,5 +52,5 @@ elif [ "$APPLICATION_TYPE" = "compliance-consumer" ]; then
 elif [ "$APPLICATION_TYPE" = "compliance-sidekiq" ]; then
 	exec bundle exec sidekiq
 elif [ "$APPLICATION_TYPE" = "compliance-prometheus-exporter" ]; then
-	exec bundle exec prometheus_exporter -c lib/graphql_collector.rb --prefix compliance_
+	exec bundle exec prometheus_exporter -a lib/graphql_collector.rb --prefix compliance_
 fi


### PR DESCRIPTION
I was passing the argument for the graphql collector wrong here, after I changed it to the right one, here's some info we can capture:

```
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allProfiles",quantile="0.99"} 0.0006016590050421655
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allProfiles",quantile="0.9"} 0.0006016590050421655
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allProfiles",quantile="0.5"} 0.0003832360089290887
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allProfiles",quantile="0.1"} 0.0002718190080486238
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allProfiles",quantile="0.01"} 0.0002718190080486238
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="Query.allProfiles"} 0.001256714022019878
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="Query.allProfiles"} 3
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.profile",quantile="0.99"} 0.01520510998670943
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.profile",quantile="0.9"} 0.01520510998670943
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.profile",quantile="0.5"} 0.01520510998670943
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.profile",quantile="0.1"} 0.01520510998670943
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.profile",quantile="0.01"} 0.01520510998670943
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="Query.profile"} 0.01520510998670943
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="Query.profile"} 1
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allSystems",quantile="0.99"} 0.001613003987586126
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allSystems",quantile="0.9"} 0.001613003987586126
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allSystems",quantile="0.5"} 0.001164866000181064
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allSystems",quantile="0.1"} 0.0007088649726938456
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.allSystems",quantile="0.01"} 0.0007088649726938456
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="Query.allSystems"} 0.010072213946841657
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="Query.allSystems"} 9
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.system",quantile="0.99"} 0.009503120993031189
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.system",quantile="0.9"} 0.009503120993031189
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.system",quantile="0.5"} 0.005399227986345068
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.system",quantile="0.1"} 0.002453616005368531
ruby_graphql_duration_seconds{key="execute_field",platform_key="Query.system",quantile="0.01"} 0.002453616005368531
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="Query.system"} 0.017355964984744787
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="Query.system"} 3
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.profiles",quantile="0.99"} 0.0001852510031312704
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.profiles",quantile="0.9"} 0.0001852510031312704
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.profiles",quantile="0.5"} 0.000178231013705954
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.profiles",quantile="0.1"} 0.000178231013705954
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.profiles",quantile="0.01"} 0.000178231013705954
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="System.profiles"} 0.0003634820168372244
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="System.profiles"} 2
ruby_graphql_duration_seconds{key="execute_field",platform_key="Profile.rules",quantile="0.99"} 9.155599400401115e-05
ruby_graphql_duration_seconds{key="execute_field",platform_key="Profile.rules",quantile="0.9"} 9.155599400401115e-05
ruby_graphql_duration_seconds{key="execute_field",platform_key="Profile.rules",quantile="0.5"} 3.452101373113692e-05
ruby_graphql_duration_seconds{key="execute_field",platform_key="Profile.rules",quantile="0.1"} 3.452101373113692e-05
ruby_graphql_duration_seconds{key="execute_field",platform_key="Profile.rules",quantile="0.01"} 3.452101373113692e-05
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="Profile.rules"} 0.00012607700773514807
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="Profile.rules"} 2
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.rule_objects_failed",quantile="0.99"} 0.1869080280011985
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.rule_objects_failed",quantile="0.9"} 0.1869080280011985
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.rule_objects_failed",quantile="0.5"} 0.153703208983643
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.rule_objects_failed",quantile="0.1"} 0.1313107119931374
ruby_graphql_duration_seconds{key="execute_field",platform_key="System.rule_objects_failed",quantile="0.01"} 0.1313107119931374
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="System.rule_objects_failed"} 0.4719219489779789
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="System.rule_objects_failed"} 3
ruby_graphql_duration_seconds{key="execute_field",platform_key="Rule.profiles",quantile="0.99"} 0.003062813979340717
ruby_graphql_duration_seconds{key="execute_field",platform_key="Rule.profiles",quantile="0.9"} 0.0005289510008879006
ruby_graphql_duration_seconds{key="execute_field",platform_key="Rule.profiles",quantile="0.5"} 0.0001927639823406935
ruby_graphql_duration_seconds{key="execute_field",platform_key="Rule.profiles",quantile="0.1"} 0.0001359050220344216
ruby_graphql_duration_seconds{key="execute_field",platform_key="Rule.profiles",quantile="0.01"} 0.0001029499981086701
ruby_graphql_duration_seconds_sum{key="execute_field",platform_key="Rule.profiles"} 0.06763151375344023
ruby_graphql_duration_seconds_count{key="execute_field",platform_key="Rule.profiles"} 180
```