### PR TITLE
Use release-date label for rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # s2i-insights-compliance
 FROM registry.access.redhat.com/ubi8/ruby-26
 
-LABEL maintainer="Insights Compliance <insights-dev@redhat.com>"
+# Update release-date on changes or rebuids
+LABEL maintainer="Insights Compliance <insights-dev@redhat.com>" \
+      com.redhat.cloud.compliance.s2i.release-date="2021-01-12"
 
-# TODO: Rename the builder environment variable to inform users about application you provide them
-ENV INSIGHTS_COMPLIANCE 0.4.2
 ENV RAILS_ENV=production RAILS_LOG_TO_STDOUT=true
 
 # TODO: Set labels used in OpenShift to describe the builder image


### PR DESCRIPTION
Until we have an automation on rebuilds we can use a label that can be change.
Once the changes merged, the image will be rebuild.

Also removes unused `INSIGHTS_COMPLIANCE` env.