### PR TITLE
chore(rubygems): RHICOMPL-1616 use the latest rubygems when building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ LABEL io.k8s.description="Base image for Red Hat Insights Compliance" \
 USER root
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     yum install -y hostname shared-mime-info && \
-    yum clean all -y
+    yum clean all -y && \
+    gem update --system --install-dir=/usr/share/gems
 USER 1001
 
 # Copy the S2I scripts to /usr/libexec/s2i, since openshift/base-centos7 image


### PR DESCRIPTION
This should take care of having the latest rubygems/bundler available for us when building. This will break the builds on `compliance-backend` until https://github.com/RedHatInsights/compliance-backend/pull/811 is merged.